### PR TITLE
learn: link to First Steps tutorial

### DIFF
--- a/learn.tt
+++ b/learn.tt
@@ -16,7 +16,7 @@
     </li>
     <li>
       <div class="clickable-whole">
-        <a href="https://nix.dev">
+        <a href="https://nix.dev/tutorials/first-steps/">
           [% PROCESS svg path="site-styles/assets/gfx-learn-develop.svg" %]
           <button>First steps with Nix</button>
         </a>


### PR DESCRIPTION
The link to "First steps with Nix" currently points to nix.dev. This changes the link to a more specific tutorial on nix.dev titled "First Steps".